### PR TITLE
refresh category bug resolved

### DIFF
--- a/src/components/SwipeableRow.tsx
+++ b/src/components/SwipeableRow.tsx
@@ -37,7 +37,9 @@ const SwipeableRow: React.FC<SwipeableRowProps> = ({
 }) => {
   const swipeableRowRef = useRef<Swipeable>(null);
 
+  // store
   const deleteFromWishList = useStore((state: any) => state.deleteFromWishList);
+  const UserDetail = useStore((state: any) => state.UserDetail);
 
   const showToast = (message: any) => {
     Toast.show({
@@ -190,7 +192,7 @@ const SwipeableRow: React.FC<SwipeableRowProps> = ({
         text: 'Delete',
         onPress: () => {
           try {
-            deleteFromWishList(id);
+            deleteFromWishList(id, UserDetail);
             showToast(`${title} is Deleted`);
           } catch (error: any) {
             console.error('Error Deleting:', error.message);

--- a/src/components/WishListFlatList.tsx
+++ b/src/components/WishListFlatList.tsx
@@ -49,7 +49,7 @@ const WishListFlatList: React.FC<WishListFlatListProps> = ({
       {showMoreModal && (
         <TouchableOpacity
           onPress={() => {
-            navigation.navigate('ModalScreen', {categoryIndex});
+            navigation.navigate('ModalScreen', {categoryIndex}, onRefresh);
           }}>
           <Feather
             name="more-horizontal"

--- a/src/screens/ModalScreen.tsx
+++ b/src/screens/ModalScreen.tsx
@@ -9,12 +9,14 @@ import {
   Share,
   TouchableOpacity,
   Alert,
+  ActivityIndicator,
 } from 'react-native';
 import {useCardAnimation} from '@react-navigation/stack';
 import {COLORS, SPACING} from '../theme/theme';
 import Feather from 'react-native-vector-icons/Feather';
 import {useStore} from '../store/store';
 import {update} from 'lodash';
+import {useState} from 'react';
 
 const DATA = [
   {
@@ -65,6 +67,7 @@ const Item = ({itemTitle, icon, categoryIndex, navigation}: ItemProps) => {
       } catch (error: any) {
         console.error('Error sharing:', error.message);
       }
+      navigation.goBack();
     } else if (action === 'Edit Category') {
       // Implement edit category logic here
       Alert.prompt(
@@ -77,8 +80,11 @@ const Item = ({itemTitle, icon, categoryIndex, navigation}: ItemProps) => {
           },
           {
             text: 'Save',
-            onPress: newCategory => {
-              updateCategory(title, newCategory, UserDetail);
+            onPress: async newCategory => {
+              await updateCategory(title, newCategory, UserDetail);
+              navigation.navigate('WishList', {
+                category: newCategory,
+              });
             },
           },
         ],
@@ -105,7 +111,6 @@ const Item = ({itemTitle, icon, categoryIndex, navigation}: ItemProps) => {
         ],
       );
     }
-    navigation.goBack();
   };
 
   return (
@@ -179,6 +184,11 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'column',
     justifyContent: 'flex-end',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   animatedView: {
     borderTopEndRadius: SPACING.space_16,

--- a/src/screens/WishListScreen.tsx
+++ b/src/screens/WishListScreen.tsx
@@ -56,7 +56,7 @@ const WishListScreen = ({route, navigation}: any) => {
           index: categories.indexOf(route.params.category),
           category: route.params.category,
         });
-      } else {
+      } else if (categoryIndex.index == 0) {
         setCategoryIndex({index: 0, category: categories[0]});
       }
     }
@@ -99,9 +99,9 @@ const WishListScreen = ({route, navigation}: any) => {
     }
   };
 
-  const onRefresh = () => {
+  const onRefresh = async () => {
     setRefreshing(true);
-    fetchWishListItems(UserDetail);
+    await fetchWishListItems(UserDetail);
     setTimeout(() => {
       setRefreshing(false);
     }, 1000);


### PR DESCRIPTION
Problem: If we pull down refresh on category it take us back to the first category.
Solution: added 'if (categoryIndex.index == 0)' in the WishListScreen to make sure it only update category if its already on 0 otherwise skip it. that will make sure it always stay on the category we are doing action on.